### PR TITLE
Improvements: skip malformed files; use all available cores.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-__pycache__
-.DS_Store

--- a/Synology.py
+++ b/Synology.py
@@ -83,7 +83,7 @@ method.set(1)
 
 def load_file():
     fname = tkinter.filedialog.askopenfilename()
-    
+
     if fname:
         try:
             pkfilebox.config(state='normal')
@@ -105,7 +105,7 @@ pufilebox = ttk.Entry(root, state='disabled')
 
 def load_filepu():
     fname = tkinter.filedialog.askopenfilename()
-    
+
     if fname:
         try:
             pufilebox.config(state='normal')
@@ -142,7 +142,7 @@ def load_decrypt_file():
         fname = tkinter.filedialog.askopenfilename()
     else:
         fname = tkinter.filedialog.askdirectory()
-    
+
     if fname:
         try:
             filebox.config(state='normal')
@@ -164,7 +164,7 @@ outputbox = ttk.Entry(root, state='disabled', width=34)
 
 def load_output():
     fname = tkinter.filedialog.askdirectory()
-    
+
     if fname:
         try:
             outputbox.config(state='normal')
@@ -198,7 +198,7 @@ def validate():
                     try:
                         run_tool()
                     except Exception as e:
-                        elogger.error(e)
+                        elogger.error(e, exc_info=e)
                         tkinter.messagebox.showwarning("Decryption", "Failed to decrypt file(s), please raise an issue using the support button located in the about option of the application menu")
                     else:
                         tkinter.messagebox.showinfo("Decryption", "Files have successfully been decrypted and can be found in the destination folder")
@@ -226,7 +226,7 @@ def validate():
                         try:
                             run_tool()
                         except Exception as e:
-                            elogger.error(e)
+                            elogger.error(e, exc_info=e)
                             tkinter.messagebox.showwarning("Decryption", "Failed to decrypt file(s), please raise an issue using the support button located in the about option of the application menu")
                         else:
                             tkinter.messagebox.showinfo("Decryption", "Files have successfully been decrypted and can be found in the destination folder")
@@ -317,7 +317,7 @@ def about_dialog():
     win.title("About")
     win.configure(bg="#e7e7e7")
     win.resizable(0,0)
-    
+
     img = ImageTk.PhotoImage(Image.open("app.gif").resize((128, 128), Image.ANTIALIAS))
     icon = ttk.Label(win, image=img)
     icon.image = img
@@ -331,7 +331,7 @@ def about_dialog():
     license.config(state='disabled', highlightbackground='grey', highlightcolor='grey', borderwidth=1, highlightthickness=1)
     support = ttk.Button(win, text="Support", command=lambda: open_url("https://github.com/anojht/synology-cloud-sync-decrypt-tool/issues"))
     donate = ttk.Button(win, text="Donate", command=lambda: open_url("https://www.paypal.me/Anojh"))
-    
+
     icon.grid(row=0, column=1, padx=10)
     name.grid(row=1, column=1, padx=10)
     author.grid(row=2, column=1)

--- a/syndecrypt/__main__.py
+++ b/syndecrypt/__main__.py
@@ -23,19 +23,20 @@ For more information, see https://github.com/anojht/synology-cloud-sync-decrypt-
 import docopt
 import os
 import logging
-    
+import sys
+
 import syndecrypt.files as files
 #import files
 import syndecrypt.util as util
 #from syndecrypt import util
 
 def main(args):
-    
+
     if args[0] == "-p":
         arguments = {"--password-file": args[1], "--private-key-file": None, "--public-key-file": None, "--output-directory": args[2], "<encrypted-file>": args[3]}
     elif args[0] == "-k":
         arguments = {"--password-file": None, "--private-key-file": args[1], "--public-key-file": args[2], "--output-directory": args[3], "<encrypted-file>": args[4]}
-    
+
     password_file_name = arguments['--password-file']
     if password_file_name != None:
         password = arguments['--password-file']
@@ -60,7 +61,7 @@ def main(args):
     f = arguments['<encrypted-file>']
     ff = os.path.abspath(f)
     fp = os.path.basename(ff)
-    
+
     if os.path.isdir(ff):
         if not os.path.isdir(os.path.join(output_dir, fp)):
             output_dir = os.path.join(output_dir, fp)
@@ -71,11 +72,9 @@ def main(args):
             structure = root.replace(ff, output_dir, 1)
             if not os.path.isdir(structure):
                 os.mkdir(structure)
-            
+
             for filename in items:
-                file_path = os.path.join(root, filename)
-                if filename != ".DS_Store":
-                    files.decrypt_file(file_path, os.path.join(structure, filename), password=password, private_key=private_key, public_key=public_key)
+                files.decrypt_file(os.path.join(root, filename), os.path.join(structure, filename), password=password, private_key=private_key, public_key=public_key)
     else:
         files.decrypt_file(ff, os.path.join(output_dir, fp), password=password, private_key=private_key, public_key=public_key)
 


### PR DESCRIPTION
This PR introduces two changes:

### Ignoring Malformed/Empty Files

I use Backblaze as my cloud storage provider, and as an implementation detail it (or Cloud Sync, unsure) scatters empty `.bzEmpty` files to represent "folders", since AFAIK it's actually just a key-value store.

Trying to decrypt these files causes the tool to die while parsing the header. Now, instead, it will skip files with missing or malformed headers.

I don't know a good way to surface this back in the UI; I was tailing the log file to watch what it was doing and where it was failing.

### Use All Available Cores

I used the standard library `multiprocessing.Pool` to multi-process the decryption process at a per-file level. This required some rearrangement of the way that the directory hierarchy was traversed, but I think this whole program operates under the assumption that the source files/folders will not be written to while decryption is happening, so it should be okay.

This solidly pegs all 8 of my late 2018 MBP's cores, which is what I wanted.